### PR TITLE
Enlarge clickable area

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -17,14 +17,11 @@ var display = {
                 m(
                     "div.outline",
                     {
-                        onclick: function () {
+                        onclick: function() {
                             copyToClipboard(token);
                         }
                     },
-                    [
-                        m("div.token", token),
-                        m("div.copy")
-                    ]
+                    [m("div.token", token), m("div.copy")]
                 )
             );
             if (progress !== null) {

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -14,14 +14,18 @@ var display = {
 
         if (token !== null) {
             nodes.push(
-                m("div.outline", [
-                    m("div.token", token),
-                    m("div.copy", {
-                        onclick: function() {
+                m(
+                    "div.outline",
+                    {
+                        onclick: function () {
                             copyToClipboard(token);
                         }
-                    })
-                ])
+                    },
+                    [
+                        m("div.token", token),
+                        m("div.copy")
+                    ]
+                )
             );
             if (progress !== null) {
                 let updateProgress = vnode => {


### PR DESCRIPTION
Hi,

I often find myself pixel-hunting the clickable SVG file to copy the totp code.

This patch enlarges the clickable area to the whole `outline` div so it's easier for clumsy people like me :-)

I'm not sure this little patch is interesting :-)

(also, this patch is just hacked together in a couple of minutes)