### PR TITLE
Add dark theme support

### DIFF
--- a/src/popup/copy-dark.svg
+++ b/src/popup/copy-dark.svg
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Capa_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 488.3 488.3"
+   style="enable-background:new 0 0 488.3 488.3;"
+   xml:space="preserve"
+   sodipodi:docname="copy-dark.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   inkscape:export-filename="/home/jman/tmp/copy.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"><metadata
+   id="metadata915"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+   id="defs913" /><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="1453"
+   inkscape:window-height="1023"
+   id="namedview911"
+   showgrid="false"
+   inkscape:zoom="1.2149552"
+   inkscape:cx="202.15159"
+   inkscape:cy="235.83297"
+   inkscape:window-x="455"
+   inkscape:window-y="12"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Capa_1" />
+<g
+   id="g908">
+	<g
+   id="g906">
+		<path
+   d="M314.25,85.4h-227c-21.3,0-38.6,17.3-38.6,38.6v325.7c0,21.3,17.3,38.6,38.6,38.6h227c21.3,0,38.6-17.3,38.6-38.6V124    C352.75,102.7,335.45,85.4,314.25,85.4z M325.75,449.6c0,6.4-5.2,11.6-11.6,11.6h-227c-6.4,0-11.6-5.2-11.6-11.6V124    c0-6.4,5.2-11.6,11.6-11.6h227c6.4,0,11.6,5.2,11.6,11.6V449.6z"
+   id="path902"
+   style="fill:#c4c4c4;fill-opacity:1"
+   inkscape:export-filename="/home/jman/tmp/copy.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96" />
+		<path
+   d="M401.05,0h-227c-21.3,0-38.6,17.3-38.6,38.6c0,7.5,6,13.5,13.5,13.5s13.5-6,13.5-13.5c0-6.4,5.2-11.6,11.6-11.6h227    c6.4,0,11.6,5.2,11.6,11.6v325.7c0,6.4-5.2,11.6-11.6,11.6c-7.5,0-13.5,6-13.5,13.5s6,13.5,13.5,13.5c21.3,0,38.6-17.3,38.6-38.6    V38.6C439.65,17.3,422.35,0,401.05,0z"
+   id="path904"
+   style="fill:#c4c4c4;fill-opacity:1"
+   inkscape:export-filename="/home/jman/tmp/copy.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96" />
+	</g>
+</g>
+</svg>

--- a/src/popup/popup.less
+++ b/src/popup/popup.less
@@ -49,4 +49,5 @@ body {
 
 .info {
     white-space: nowrap;
+    color: #000;
 }

--- a/src/popup/popup.less
+++ b/src/popup/popup.less
@@ -53,14 +53,19 @@ body {
 
 @media (prefers-color-scheme: dark) {
     body {
-        background: black;
-        color: white;
+        background: #414141;
+        outline: 1px solid #7f7f7f;
+        color: #c4c4c4;
+    }
+    .copy {
+        background: url("../popup/copy-dark.svg") no-repeat;
     }
 }
 
 @media (prefers-color-scheme: light) {
     body {
-        background: white;
-        color: black;
+        background: #f1f3f5;
+        outline: 1px solid #7f7f7f;
+        color: #343a40;
     }
 }

--- a/src/popup/popup.less
+++ b/src/popup/popup.less
@@ -49,5 +49,18 @@ body {
 
 .info {
     white-space: nowrap;
-    color: #000;
+}
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background: black;
+        color: white;
+    }
+}
+
+@media (prefers-color-scheme: light) {
+    body {
+        background: white;
+        color: black;
+    }
 }


### PR DESCRIPTION
fixes #15 

In order to reproduce:

in `about:config` set:
```
browser.in-content.dark-mode    true
widget.content.allow-gtk-dark-theme    true
browser.display.use_system_colors    true
```
and start firefox with `GTK_THEME=Adwaita:dark firefox`

To test dark theme, add `ui.systemUsesDarkTheme=1` in about:config